### PR TITLE
Fix WordSet slices with Python 2

### DIFF
--- a/jaraco/text.py
+++ b/jaraco/text.py
@@ -256,6 +256,10 @@ class WordSet(tuple):
 			result = WordSet(result)
 		return result
 
+	# for compatibility with Python 2
+	def __getslice__(self, i, j):
+		return self.__getitem__(slice(i, j))
+
 	@classmethod
 	def parse(cls, identifier):
 		matches = cls._pattern.finditer(identifier)


### PR DESCRIPTION
Hi Jason,
In order to maintain compatibility with Python 2, `__getslice__` should be implemented in addition to `__getitem__`.
https://docs.python.org/2/reference/datamodel.html#object.__getslice__
This fixes failing tests with Python 2.
