### PR TITLE
Drop dependency on `jaraco.context` (+`backports`)

### DIFF
--- a/jaraco/text/__init__.py
+++ b/jaraco/text/__init__.py
@@ -10,7 +10,6 @@ try:
 except ImportError:  # pragma: nocover
     from importlib_resources import files  # type: ignore
 
-from jaraco.context import ExceptionTrap
 from jaraco.functools import compose, method_cache
 
 
@@ -134,12 +133,7 @@ class FoldedCase(str):
         return pattern.split(self, maxsplit)
 
 
-# Python 3.8 compatibility
-_unicode_trap = ExceptionTrap(UnicodeDecodeError)
-
-
-@_unicode_trap.passes
-def is_decodable(value):
+def is_decodable(value: bytes) -> bool:
     r"""
     Return True if the supplied value is decodable (using the default
     encoding).
@@ -149,7 +143,11 @@ def is_decodable(value):
     >>> is_decodable(b'\x32')
     True
     """
-    value.decode()
+    try:
+        value.decode()
+        return True
+    except UnicodeDecodeError:
+        return False
 
 
 def is_binary(value):

--- a/newsfragments/15.misc.rst
+++ b/newsfragments/15.misc.rst
@@ -1,0 +1,1 @@
+Drop dependency on ``jaraco.context`` -- by :user:`Avasam`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
 	"jaraco.functools",
-	"jaraco.context >= 4.1",
 	'importlib_resources; python_version < "3.9"',
 	"autocommand",
 	"inflect",


### PR DESCRIPTION
It seems overkill to pull in `jaraco.context` and its dependencies just for that one function.
This should also allows removing both `jaraco.context` and `backports` from `setuptools`'s vendored dependencies as they were both only transitive from `jaraco.context`

Relates to:
- https://github.com/pypa/setuptools/issues/2825
- https://github.com/pypa/setuptools/issues/4476
- https://github.com/pypa/setuptools/issues/4508
- https://github.com/pypa/setuptools/issues/4509