### PR TITLE
Drop dependency on `inflect` (+`typeguard`&`typing_extensions`)

### DIFF
--- a/jaraco/text/show-newlines.py
+++ b/jaraco/text/show-newlines.py
@@ -1,5 +1,4 @@
 import autocommand
-import inflect
 from more_itertools import always_iterable
 
 import jaraco.text
@@ -21,10 +20,8 @@ def report_newlines(filename):
     """
     newlines = jaraco.text.read_newlines(filename)
     count = len(tuple(always_iterable(newlines)))
-    engine = inflect.engine()
     print(
-        engine.plural_noun("newline", count),
-        engine.plural_verb("is", count),
+        *(("newline", "is") if count == 1 else ("newlines", "are")),
         repr(newlines),
     )
 

--- a/newsfragments/16.misc.rst
+++ b/newsfragments/16.misc.rst
@@ -1,0 +1,1 @@
+Drop dependency on ``inflect`` -- by :user:`Avasam`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
 	"jaraco.context >= 4.1",
 	'importlib_resources; python_version < "3.9"',
 	"autocommand",
-	"inflect",
 	"more_itertools",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
It seems overkill to pull in `inflect` and its dependencies just for that one function. Especially for such a specific and simple single use case.
This should also allows removing all of the following from `setuptools` vendored dependencies:
- `inflect`
- `typeguard`
- `typing_extensions`

Relates to:
- https://github.com/pypa/setuptools/issues/2345
- https://github.com/pypa/setuptools/issues/2825
- https://github.com/pypa/setuptools/issues/4324
- https://github.com/pypa/setuptools/issues/4480