### PR TITLE
Experiment: "deselecting" default dependencies using extras

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,3 +14,11 @@ def tmp_path(tmp_path):
     Override tmp_path to wrap in a more modern interface.
     """
     return pathlib.Path(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def populate_doctest_namespace(doctest_namespace):
+    # Workaround for module getattr limitation (names not available in ``globals()``)
+    from jaraco.text import lorem_ipsum
+
+    doctest_namespace['lorem_ipsum'] = lorem_ipsum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.8"
 dependencies = [
 	"jaraco.functools",
 	"jaraco.context >= 4.1",
-	'importlib_resources; python_version < "3.9"',
+	'importlib_resources; python_version < "3.9" and extra != "minimal"',
 	"autocommand",
 	"more_itertools",
 ]
@@ -56,5 +56,6 @@ doc = [
 	# local
 ]
 inflect = ["inflect"]
+minimal = []
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 	"jaraco.functools",
 	"jaraco.context >= 4.1",
 	'importlib_resources; python_version < "3.9" and extra != "minimal"',
-	"autocommand",
+	'autocommand; extra != "minimal"',
 	"more_itertools",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
This is an experiment to test the waters regarding the possibility discussed in https://github.com/pypa/setuptools/pull/4457#issuecomment-2214904629:

> Yeah, I bemoan these transitive dependencies too. I would like to refactor some of these supporting libraries so that they have fewer unused dependencies (as inflect and autocommand are in many cases). This problem would be easier if packages could have "default extras" that could be deselected on install (or vendoring).

Although we don't yet have the concept of "default" extras in Python, we can implement "exclusion" extras with an environment marker: `dependency==0.42; extra != "xyz"`.

This does however mean that the code has to be written in a way that it allows for the "deselected dependency" to lazily evaluated or not evaluated at all. When the import statement resides in an isolated submodule that is easy and does not require many changes. However if the import statement is in `__init__.py` or in a submodule that is imported in other parts of the codebase, things start to be more complicated.

The reason why I decided to try the experiment with `jaraco.text` is because it seems to be the dependency of setuptools that brings most transient dependencies with itself. According to `pipdeptree`:

```console
importlib_metadata==8.2.0
  zipp==3.20.0
jaraco.text==4.0.0
  autocommand==2.2.2
  importlib_resources==6.4.2
    zipp==3.20.0
  jaraco.context==5.3.0
    backports.tarfile==1.2.0
  jaraco.functools==4.0.2
    more-itertools==10.4.0
  more-itertools==10.4.0
ordered-set==4.1.0
packaging==24.1
platformdirs==4.2.2
tomli==2.0.1
wheel==0.44.0
```

This PR is by no means exhaustive, I only implemented the 2 most obvious optional exclusions to me.