### PR TITLE
Making `autocommand` an explicit opt-in extra because it's LGPL code

### DIFF
--- a/jaraco/text/show-newlines.py
+++ b/jaraco/text/show-newlines.py
@@ -2,10 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import autocommand
-import inflect
-from more_itertools import always_iterable
-
 import jaraco.text
 
 if TYPE_CHECKING:
@@ -37,4 +33,11 @@ def report_newlines(filename: FileDescriptorOrPath) -> None:
     )
 
 
-autocommand.autocommand(__name__)(report_newlines)
+try:
+    import autocommand
+    import inflect
+    from more_itertools import always_iterable
+
+    autocommand.autocommand(__name__)(report_newlines)
+except ModuleNotFoundError as error:  # pragma: nocover
+    print(f"{error}. Did you forget to install it or 'jaraco.text[scripts]' ?")

--- a/jaraco/text/strip-prefix.py
+++ b/jaraco/text/strip-prefix.py
@@ -1,7 +1,5 @@
 import sys
 
-import autocommand
-
 from jaraco.text import Stripper
 
 
@@ -18,4 +16,9 @@ def strip_prefix() -> None:
     sys.stdout.writelines(Stripper.strip_prefix(sys.stdin).lines)
 
 
-autocommand.autocommand(__name__)(strip_prefix)
+try:
+    import autocommand
+
+    autocommand.autocommand(__name__)(strip_prefix)
+except ModuleNotFoundError as error:  # pragma: nocover
+    print(f"{error}. Did you forget to install it or `jaraco.text[autocommand]` ?")

--- a/newsfragments/24.feature.rst
+++ b/newsfragments/24.feature.rst
@@ -1,0 +1,1 @@
+Due to concerns with ``autocommand`` being licensed under LGPLv3, the scripts-only dependencies have been made optional and installable with the ``[scripts]`` extra -- by :user:`Avasam`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ license = "MIT"
 dependencies = [
 	"jaraco.functools",
 	"jaraco.context >= 4.1",
-	"autocommand",
-	"more_itertools",
 ]
 dynamic = ["version"]
 
@@ -55,7 +53,11 @@ doc = [
 
 	# local
 ]
-inflect = ["inflect"]
+scripts = [
+	"autocommand",
+	"inflect",
+	"more_itertools",
+]
 
 check = [
 	"pytest-checkdocs >= 2.4",
@@ -78,6 +80,7 @@ type = [
 	"mypy < 1.19; python_implementation == 'PyPy'",
 
 	# local
+	"jaraco.text[scripts]"
 ]
 
 


### PR DESCRIPTION
One option to address https://github.com/pypa/setuptools/issues/5045 is simply to make `autocommand` an optional dependency.

Also relates to https://github.com/pypa/setuptools/issues/5049

Alternative to, and closes #25 + closes #26

Another alternative if/when https://peps.python.org/pep-0771/#overriding-default-extras gets accepted would be default extras, since setuptools could opt-out in a standard manner.
> An empty set of extras, such as package[] should be interpreted as meaning that the package should be installed without any default extras
