### PR TITLE
Replaced ``autocommand`` usage with ``Typer``

### DIFF
--- a/jaraco/text/__init__.py
+++ b/jaraco/text/__init__.py
@@ -7,14 +7,7 @@ import sys
 import textwrap
 from collections.abc import Callable, Generator, Iterable, Sequence
 from importlib.resources import files
-from typing import (
-    TYPE_CHECKING,
-    Literal,
-    Protocol,
-    SupportsIndex,
-    TypeVar,
-    overload,
-)
+from typing import TYPE_CHECKING, Literal, Protocol, SupportsIndex, TypeVar, overload
 
 from jaraco.context import ExceptionTrap
 from jaraco.functools import compose, method_cache

--- a/jaraco/text/show-newlines.py
+++ b/jaraco/text/show-newlines.py
@@ -7,10 +7,7 @@ from more_itertools import always_iterable
 import jaraco.text
 
 
-# filename is technically a FileDescriptorOrPath, but Typer doesn't support Unions yet
-# and this file is script-only (not importable) anyway.
-# https://github.com/fastapi/typer/issues/461
-def report_newlines(filename: str) -> None:
+def report_newlines(input: typer.FileText) -> None:
     r"""
     Report the newlines in the indicated file.
 
@@ -24,7 +21,7 @@ def report_newlines(filename: str) -> None:
     >>> report_newlines(filename)
     newlines are ('\n', '\r\n')
     """
-    newlines = jaraco.text.read_newlines(filename)
+    newlines = jaraco.text.read_newlines(input)
     count = len(tuple(always_iterable(newlines)))
     engine = inflect.engine()
     print(

--- a/jaraco/text/show-newlines.py
+++ b/jaraco/text/show-newlines.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-import autocommand
 import inflect
+import typer
 from more_itertools import always_iterable
 
 import jaraco.text
 
-if TYPE_CHECKING:
-    from _typeshed import FileDescriptorOrPath
 
-
-def report_newlines(filename: FileDescriptorOrPath) -> None:
+# filename is technically a FileDescriptorOrPath, but Typer doesn't support Unions yet
+# and this file is script-only (not importable) anyway.
+# https://github.com/fastapi/typer/issues/461
+def report_newlines(filename: str) -> None:
     r"""
     Report the newlines in the indicated file.
 
@@ -37,4 +35,4 @@ def report_newlines(filename: FileDescriptorOrPath) -> None:
     )
 
 
-autocommand.autocommand(__name__)(report_newlines)
+__name__ == '__main__' and typer.run(report_newlines)  # type: ignore[func-returns-value]

--- a/jaraco/text/strip-prefix.py
+++ b/jaraco/text/strip-prefix.py
@@ -1,6 +1,6 @@
 import sys
 
-import autocommand
+import typer
 
 from jaraco.text import Stripper
 
@@ -18,4 +18,4 @@ def strip_prefix() -> None:
     sys.stdout.writelines(Stripper.strip_prefix(sys.stdin).lines)
 
 
-autocommand.autocommand(__name__)(strip_prefix)
+__name__ == '__main__' and typer.run(strip_prefix)  # type: ignore[func-returns-value]

--- a/newsfragments/25.feature.rst
+++ b/newsfragments/25.feature.rst
@@ -1,0 +1,1 @@
+Replaced ``autocommand`` usage with ``Typer`` -- by :user:`Avasam`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ classifiers = [
 requires-python = ">=3.9"
 license = "MIT"
 dependencies = [
-	"jaraco.functools",
 	"jaraco.context >= 4.1",
-	"autocommand",
+	"jaraco.functools",
 	"more_itertools",
+	"typer-slim",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
One option to address https://github.com/pypa/setuptools/issues/5045 is to replace ``autocommand`` (LGPLv3) usage with ``Typer`` (MIT).

Also relates to https://github.com/pypa/setuptools/issues/5049

Alternative to, and closes #24 + closes #26

This would also help with https://github.com/jaraco/jaraco.text/pull/23