### PR TITLE
Removed ``autocommand`` usage

### DIFF
--- a/jaraco/text/__init__.py
+++ b/jaraco/text/__init__.py
@@ -7,14 +7,7 @@ import sys
 import textwrap
 from collections.abc import Callable, Generator, Iterable, Sequence
 from importlib.resources import files
-from typing import (
-    TYPE_CHECKING,
-    Literal,
-    Protocol,
-    SupportsIndex,
-    TypeVar,
-    overload,
-)
+from typing import TYPE_CHECKING, Literal, Protocol, SupportsIndex, TypeVar, overload
 
 from jaraco.context import ExceptionTrap
 from jaraco.functools import compose, method_cache

--- a/jaraco/text/show-newlines.py
+++ b/jaraco/text/show-newlines.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
-import autocommand
 import inflect
 from more_itertools import always_iterable
 
@@ -37,4 +37,4 @@ def report_newlines(filename: FileDescriptorOrPath) -> None:
     )
 
 
-autocommand.autocommand(__name__)(report_newlines)
+__name__ == '__main__' and report_newlines(*sys.argv[1:])  # type: ignore[func-returns-value]

--- a/jaraco/text/strip-prefix.py
+++ b/jaraco/text/strip-prefix.py
@@ -1,7 +1,5 @@
 import sys
 
-import autocommand
-
 from jaraco.text import Stripper
 
 
@@ -18,4 +16,4 @@ def strip_prefix() -> None:
     sys.stdout.writelines(Stripper.strip_prefix(sys.stdin).lines)
 
 
-autocommand.autocommand(__name__)(strip_prefix)
+__name__ == '__main__' and strip_prefix()  # type: ignore[func-returns-value]

--- a/newsfragments/26.feature.rst
+++ b/newsfragments/26.feature.rst
@@ -1,0 +1,1 @@
+Removed ``autocommand`` as a dependency -- by :user:`Avasam`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ license = "MIT"
 dependencies = [
 	"jaraco.functools",
 	"jaraco.context >= 4.1",
-	"autocommand",
 	"more_itertools",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
One option to address https://github.com/pypa/setuptools/issues/5045 is to simply remove ``autocommand`` usage entirely. Imo using autocommand and/or Typer here felt overkill. The following error really isn't that obscure:
<img width="814" height="217" alt="image" src="https://github.com/user-attachments/assets/777ea2e3-7858-4744-b16b-6626696ae71e" />

Also relates to https://github.com/pypa/setuptools/issues/5049

Alternative to, and closes #24 + closes #25
