### PR TITLE
Fixed `join_continuation`'s parameter type annotation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,9 +58,11 @@ extensions += ['sphinx.ext.extlinks']
 extensions += ['jaraco.tidelift']
 nitpick_ignore += [
     ("py:class", "FileDescriptorOrPath"),
-    ("py:class", "_GetItemIterable"),
     ("py:class", "_SupportsDecode"),
     ("py:class", "_TranslateTable"),
+    ("py:class", "SupportsGetItem"),
+    ("py:class", "SupportsNext"),
+    ("py:class", "SupportsIter"),
     ("py:class", "itertools.chain"),
     ("py:class", "jaraco.text._SupportsDecode"),
     ("py:class", "jaraco.text._T"),

--- a/jaraco/text/__init__.py
+++ b/jaraco/text/__init__.py
@@ -29,12 +29,13 @@ else:  # pragma: no cover
     from importlib.abc import Traversable
 
 if TYPE_CHECKING:
-    from _typeshed import FileDescriptorOrPath, SupportsGetItem
+    from _typeshed import (
+        FileDescriptorOrPath,
+        SupportsIter,
+        SupportsNext,
+    )
     from typing_extensions import Self, TypeAlias, TypeGuard, Unpack
 
-    _T_co = TypeVar("_T_co", covariant=True)
-    # Same as builtins._GetItemIterable from typeshed
-    _GetItemIterable: TypeAlias = SupportsGetItem[int, _T_co]
     Openable: TypeAlias = FileDescriptorOrPath
 else:
     Openable = Union[str, bytes, os.PathLike, int]
@@ -662,7 +663,7 @@ def drop_comment(line: str) -> str:
     return line.partition(' #')[0]
 
 
-def join_continuation(lines: _GetItemIterable[str]) -> Generator[str]:
+def join_continuation(lines: SupportsIter[SupportsNext[str]]) -> Generator[str]:
     r"""
     Join lines continued by a trailing backslash.
 
@@ -686,7 +687,7 @@ def join_continuation(lines: _GetItemIterable[str]) -> Generator[str]:
     ['foo']
     """
     lines_ = iter(lines)
-    for item in lines_:
+    for item in lines_:  # type: ignore[attr-defined] # A bit of a false positive with iteration dunder fallback
         while item.endswith('\\'):
             try:
                 item = item[:-2].strip() + next(lines_)

--- a/newsfragments/28.bugfix.rst
+++ b/newsfragments/28.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `join_continuation`'s parameter type annotation -- by :user:`Avasam`

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from jaraco.text import join_continuation
+
+
+def test_join_continuation_typing() -> None:
+    """
+    Ensures that the type annotation for join_continuation matches what we expect at runtime,
+    since checkers seem to give a false-positive on supporting ``__iter__`` and ``__next__``.
+    """
+
+    good: list[str] = ['foo \\', 'bar', 'baz']
+    expected: list[str] = ['foobar', 'baz']
+
+    # Ensure consistency at runtime for different iterables and no type error
+    assert list(join_continuation(good)) == expected
+    assert list(join_continuation(tuple(good))) == expected
+    assert list(join_continuation(map(lambda string: string, good))) == expected
+    assert list(join_continuation(iter(good))) == expected
+    assert list(join_continuation({string: None for string in good})) == expected
+
+    # NOTE: str isn't an expected use-case
+    # but unfortunately a str is an iterable of str, so we can't validate
+
+    # iter supports SupportsGetItem[int, str], but we don't !
+    bad: dict[int, str] = {i: string for (i, string) in enumerate(good)}
+    with pytest.raises(AttributeError):
+        list(join_continuation(bad))  # type: ignore[arg-type] # Testing for type error here!


### PR DESCRIPTION
This should solve a type issue with setuptools passing in a `map[str]` by accounting for more possible overloads of `iter`. Whilst also slightly simplifying type import.

This is the failing usage in setuptools:
```py
from collections.abc import Iterable, Iterator

def parse_strings(strs: str | Iterable[str]) -> Iterator[str]:
    return text.join_continuation(map(text.drop_comment, text.yield_lines(strs)))
```

Normally I'd add a test with the above snippet to ensure it is caught statically (and that runtime matches the type expectation by not crashing), but I think this project uses docstring tests.