### PR TITLE
Replace typer-slim dependency with typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 	"jaraco.context >= 4.1",
 	"jaraco.functools",
 	"more_itertools",
-	"typer-slim",
+	"typer",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Upstream has deprecated `typer-slim`, and it’s now just a shallow wrapper around `typer`. See https://github.com/fastapi/typer/pull/1522, https://github.com/fastapi/typer/blob/0.23.0/docs/release-notes.md#0220.