### PR TITLE
Moved commands only requirements to a commands extra

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,8 +17,3 @@ disable_error_code =
 # Will be replaced by pathlib in 3.10
 [mypy-pathlib2.*]
 ignore_missing_imports = True
-
-# jaraco/jaraco.develop#20
-# Lucretiel/autocommand#38
-[mypy-autocommand.*]
-ignore_missing_imports = True

--- a/newsfragments/30.feature.rst
+++ b/newsfragments/30.feature.rst
@@ -1,0 +1,1 @@
+Moved commands only requirements to a ``commands`` extra -- by :user:`Avasam`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ license = "MIT"
 dependencies = [
 	"jaraco.context >= 4.1",
 	"jaraco.functools",
-	"more_itertools",
-	"typer-slim",
 ]
 dynamic = ["version"]
 
@@ -55,7 +53,6 @@ doc = [
 
 	# local
 ]
-inflect = ["inflect"]
 
 check = [
 	"pytest-checkdocs >= 2.4",
@@ -78,7 +75,16 @@ type = [
 	"mypy < 1.19; python_implementation == 'PyPy'",
 
 	# local
+	"jaraco.text[commands]"
 ]
+
+commands = [
+	"inflect",
+	"more_itertools",
+	"typer",
+]
+# Kept for backwards compatibility
+inflect = ["jaraco.text[commands]"]
 
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Something I've already suggested in the past, but want to push for again (especially given our bad timing with `typer-slim` not being so slim anymore... https://github.com/fastapi/typer/pull/1522) 

There was already an `inflect` extra doing essentially just this

Closes #29
Reduces required dependencies
Reduces build dependencies (for setuptools' sake)